### PR TITLE
Fix Headers.extend keys iteration

### DIFF
--- a/src/geventhttpclient/header.py
+++ b/src/geventhttpclient/header.py
@@ -152,7 +152,7 @@ class Headers(dict):
             for field in other:
                 self.add(field, other[field])
         elif hasattr(other, "keys"):
-            for field in other.fields():
+            for field in other.keys():
                 self.add(field, other[field])
         else:
             for field, value in other:
@@ -167,7 +167,7 @@ class Headers(dict):
         while preserving case-sensitive header fields.
         """
         if len(args) > 1:
-            raise TypeError(f"extend() takes at most 1 positional argument ({len(args)} given)")
+            raise TypeError(f"update() takes at most 1 positional argument ({len(args)} given)")
         other = args[0] if len(args) >= 1 else ()
 
         if isinstance(other, type(self)):

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -1,6 +1,7 @@
 import random
 import string
 from datetime import datetime
+from email.message import Message
 from http.cookiejar import CookieJar
 from urllib.request import Request
 
@@ -225,3 +226,14 @@ def test_compat_dict():
     assert d["D"] == "asdf"
     assert d["E"] == "d, f"
     assert d["Cookie"] == "d, e, f"
+
+
+def test_extend_with_keys():
+    msg = Message()
+    msg["Foo"] = "bar"
+    msg["Baz"] = "qux"
+
+    h = Headers()
+    h.extend(msg)
+    assert h["Foo"] == "bar"
+    assert h["Baz"] == "qux"


### PR DESCRIPTION
## Summary
- handle non-mapping objects with `keys()` in `Headers.extend`
- correct positional argument error message in `Headers.update`
- add regression test for extending with `keys()`-only objects

------
https://chatgpt.com/codex/tasks/task_e_68a6f0bdc758832d964c394f49472436